### PR TITLE
Address feedback from LPC

### DIFF
--- a/isa/kernel.org/instruction-set.rst
+++ b/isa/kernel.org/instruction-set.rst
@@ -76,7 +76,7 @@ imm            offset   src              dst                   opcode
 =============  =======  ===============  ====================  ============
 
 imm         
-  integer immediate value
+  signed integer immediate value
 
 offset
   signed integer offset used with pointer arithmetic
@@ -648,7 +648,7 @@ opcode  imm   description                                          reference
 0xd4    0x40  dst = htole64(dst)                                   `Byte swap instructions`_
 0xd5    any   if dst s<= imm goto +offset                          `Jump instructions`_
 0xd6    any   if (int32_t)dst s<= (int32_t)imm goto +offset        `Jump instructions`_
-0xc3    0x00  lock \*(uint64_t \*)(dst + offset) += src            `Atomic operations`_
+0xdb    0x00  lock \*(uint64_t \*)(dst + offset) += src            `Atomic operations`_
 0xdb    0x01  lock::                                               `Atomic operations`_
 
                   *(uint64_t *)(dst + offset) += src

--- a/isa/kernel.org/instruction-set.rst
+++ b/isa/kernel.org/instruction-set.rst
@@ -327,6 +327,14 @@ with the remaining registers being ignored.  The definition of a helper function
 is responsible for specifying the type (e.g., integer, pointer, etc.) of the value returned,
 the number of arguments, and the type of each argument.
 
+Note that ``BPF_CALL | BPF_X | BPF_JMP`` (0x8d), where the helper function integer
+would be read from a specified register, is not currently permitted.
+
+   **Note**
+
+   *Clang implementation*:
+   Clang will generate this invalid instruction if ``-O0`` is used.
+
 Load and store instructions
 ===========================
 

--- a/isa/kernel.org/instruction-set.rst
+++ b/isa/kernel.org/instruction-set.rst
@@ -503,193 +503,193 @@ Appendix
 
 For reference, the following table lists opcodes in order by value.
 
-======  ====  ===================================================  =============
-opcode  imm   description                                          reference 
-======  ====  ===================================================  =============
-0x04    any   dst = (uint32_t)(dst + imm)                          `Arithmetic instructions`_
-0x05    0x00  goto +offset                                         `Jump instructions`_
-0x07    any   dst += imm                                           `Arithmetic instructions`_
-0x0c    0x00  dst = (uint32_t)(dst + src)                          `Arithmetic instructions`_
-0x0f    0x00  dst += src                                           `Arithmetic instructions`_
-0x14    any   dst = (uint32_t)(dst - imm)                          `Arithmetic instructions`_
-0x15    any   if dst == imm goto +offset                           `Jump instructions`_
-0x16    any   if (uint32_t)dst == imm goto +offset                 `Jump instructions`_
-0x17    any   dst -= imm                                           `Arithmetic instructions`_
-0x18    any   dst = imm                                            `Load and store instructions`_
-0x1c    0x00  dst = (uint32_t)(dst - src)                          `Arithmetic instructions`_
-0x1d    0x00  if dst == src goto +offset                           `Jump instructions`_
-0x1e    0x00  if (uint32_t)dst == (uint32_t)src goto +offset       `Jump instructions`_
-0x1f    0x00  dst -= src                                           `Arithmetic instructions`_
-0x20    any   (deprecated, implementation-specific)                `Legacy BPF Packet access instructions`_
-0x24    any   dst = (uint32_t)(dst \* imm)                         `Arithmetic instructions`_
-0x25    any   if dst > imm goto +offset                            `Jump instructions`_
-0x26    any   if (uint32_t)dst > imm goto +offset                  `Jump instructions`_
-0x27    any   dst \*= imm                                          `Arithmetic instructions`_
-0x28    any   (deprecated, implementation-specific)                `Legacy BPF Packet access instructions`_
-0x2c    0x00  dst = (uint32_t)(dst \* src)                         `Arithmetic instructions`_
-0x2d    0x00  if dst > src goto +offset                            `Jump instructions`_
-0x2e    0x00  if (uint32_t)dst > (uint32_t)src goto +offset        `Jump instructions`_
-0x2f    0x00  dst \*= src                                          `Arithmetic instructions`_
-0x30    any   (deprecated, implementation-specific)                `Legacy BPF Packet access instructions`_
-0x34    any   dst = (uint32_t)((imm != 0) ? (dst / imm) : 0)       `Arithmetic instructions`_
-0x35    any   if dst >= imm goto +offset                           `Jump instructions`_
-0x36    any   if (uint32_t)dst >= imm goto +offset                 `Jump instructions`_
-0x37    any   dst = (imm != 0) ? (dst / imm) : 0                   `Arithmetic instructions`_
-0x38    any   (deprecated, implementation-specific)                `Legacy BPF Packet access instructions`_
-0x3c    0x00  dst = (uint32_t)((imm != 0) ? (dst / src) : 0)       `Arithmetic instructions`_
-0x3d    0x00  if dst >= src goto +offset                           `Jump instructions`_
-0x3e    0x00  if (uint32_t)dst >= (uint32_t)src goto +offset       `Jump instructions`_
-0x3f    0x00  dst = (src !+ 0) ? (dst / src) : 0                   `Arithmetic instructions`_
-0x40    any   (deprecated, implementation-specific)                `Legacy BPF Packet access instructions`_
-0x44    any   dst = (uint32_t)(dst \| imm)                         `Arithmetic instructions`_
-0x45    any   if dst & imm goto +offset                            `Jump instructions`_
-0x46    any   if (uint32_t)dst & imm goto +offset                  `Jump instructions`_
-0x47    any   dst \|= imm                                          `Arithmetic instructions`_
-0x48    any   (deprecated, implementation-specific)                `Legacy BPF Packet access instructions`_
-0x4c    0x00  dst = (uint32_t)(dst \| src)                         `Arithmetic instructions`_
-0x4d    0x00  if dst & src goto +offset                            `Jump instructions`_
-0x4e    0x00  if (uint32_t)dst & (uint32_t)src goto +offset        `Jump instructions`_
-0x4f    0x00  dst \|= src                                          `Arithmetic instructions`_
-0x50    any   (deprecated, implementation-specific)                `Legacy BPF Packet access instructions`_
-0x54    any   dst = (uint32_t)(dst & imm)                          `Arithmetic instructions`_
-0x55    any   if dst != imm goto +offset                           `Jump instructions`_
-0x56    any   if (uint32_t)dst != imm goto +offset                 `Jump instructions`_
-0x57    any   dst &= imm                                           `Arithmetic instructions`_
-0x58    any   (deprecated, implementation-specific)                `Legacy BPF Packet access instructions`_
-0x5c    0x00  dst = (uint32_t)(dst & src)                          `Arithmetic instructions`_
-0x5d    0x00  if dst != src goto +offset                           `Jump instructions`_
-0x5e    0x00  if (uint32_t)dst != (uint32_t)src goto +offset       `Jump instructions`_
-0x5f    0x00  dst &= src                                           `Arithmetic instructions`_
-0x61    0x00  dst = \*(uint32_t \*)(src + offset)                  `Load and store instructions`_
-0x62    any   \*(uint32_t \*)(dst + offset) = imm                  `Load and store instructions`_
-0x63    0x00  \*(uint32_t \*)(dst + offset) = src                  `Load and store instructions`_
-0x64    any   dst = (uint32_t)(dst << imm)                         `Arithmetic instructions`_
-0x65    any   if dst s> imm goto +offset                           `Jump instructions`_
-0x66    any   if (int32_t)dst s> (int32_t)imm goto +offset         `Jump instructions`_
-0x67    any   dst <<= imm                                          `Arithmetic instructions`_
-0x69    0x00  dst = \*(uint16_t \*)(src + offset)                  `Load and store instructions`_
-0x6a    any   \*(uint16_t \*)(dst + offset) = imm                  `Load and store instructions`_
-0x6b    0x00  \*(uint16_t \*)(dst + offset) = src                  `Load and store instructions`_
-0x6c    0x00  dst = (uint32_t)(dst << src)                         `Arithmetic instructions`_
-0x6d    0x00  if dst s> src goto +offset                           `Jump instructions`_
-0x6e    0x00  if (int32_t)dst s> (int32_t)src goto +offset         `Jump instructions`_
-0x6f    0x00  dst <<= src                                          `Arithmetic instructions`_
-0x71    0x00  dst = \*(uint8_t \*)(src + offset)                   `Load and store instructions`_
-0x72    any   \*(uint8_t \*)(dst + offset) = imm                   `Load and store instructions`_
-0x73    0x00  \*(uint8_t \*)(dst + offset) = src                   `Load and store instructions`_
-0x74    any   dst = (uint32_t)(dst >> imm)                         `Arithmetic instructions`_
-0x75    any   if dst s>= imm goto +offset                          `Jump instructions`_
-0x76    any   if (int32_t)dst s>= (int32_t)imm goto +offset        `Jump instructions`_
-0x77    any   dst >>= imm                                          `Arithmetic instructions`_
-0x79    0x00  dst = \*(uint64_t \*)(src + offset)                  `Load and store instructions`_
-0x7a    any   \*(uint64_t \*)(dst + offset) = imm                  `Load and store instructions`_
-0x7b    0x00  \*(uint64_t \*)(dst + offset) = src                  `Load and store instructions`_
-0x7c    0x00  dst = (uint32_t)(dst >> src)                         `Arithmetic instructions`_
-0x7d    0x00  if dst s>= src goto +offset                          `Jump instructions`_
-0x7e    0x00  if (int32_t)dst s>= (int32_t)src goto +offset        `Jump instructions`_
-0x7f    0x00  dst >>= src                                          `Arithmetic instructions`_
-0x84    0x00  dst = (uint32_t)-dst                                 `Arithmetic instructions`_
-0x85    any   call imm                                             `Jump instructions`_
-0x87    0x00  dst = -dst                                           `Arithmetic instructions`_
-0x94    any   dst = (uint32_t)((imm != 0) ? (dst % imm) : imm)     `Arithmetic instructions`_
-0x95    0x00  return                                               `Jump instructions`_
-0x97    any   dst = (imm != 0) ? (dst % imm) : imm                 `Arithmetic instructions`_
-0x9c    0x00  dst = (uint32_t)((src != 0) ? (dst % src) : src)     `Arithmetic instructions`_
-0x9f    0x00  dst = (src != 0) ? (dst % src) : src                 `Arithmetic instructions`_
-0xa4    any   dst = (uint32_t)(dst ^ imm)                          `Arithmetic instructions`_
-0xa5    any   if dst < imm goto +offset                            `Jump instructions`_
-0xa6    any   if (uint32_t)dst < imm goto +offset                  `Jump instructions`_
-0xa7    any   dst ^= imm                                           `Arithmetic instructions`_
-0xac    0x00  dst = (uint32_t)(dst ^ src)                          `Arithmetic instructions`_
-0xad    0x00  if dst < src goto +offset                            `Jump instructions`_
-0xae    0x00  if (uint32_t)dst < (uint32_t)src goto +offset        `Jump instructions`_
-0xaf    0x00  dst ^= src                                           `Arithmetic instructions`_
-0xb4    any   dst = (uint32_t) imm                                 `Arithmetic instructions`_
-0xb5    any   if dst <= imm goto +offset                           `Jump instructions`_
-0xa6    any   if (uint32_t)dst <= imm goto +offset                 `Jump instructions`_
-0xb7    any   dst = imm                                            `Arithmetic instructions`_
-0xbc    0x00  dst = (uint32_t) src                                 `Arithmetic instructions`_
-0xbd    0x00  if dst <= src goto +offset                           `Jump instructions`_
-0xbe    0x00  if (uint32_t)dst <= (uint32_t)src goto +offset       `Jump instructions`_
-0xbf    0x00  dst = src                                            `Arithmetic instructions`_
-0xc3    0x00  lock \*(uint32_t \*)(dst + offset) += src            `Atomic operations`_
-0xc3    0x01  lock::                                               `Atomic operations`_
+======  ====  ====  ===================================================  ========================================
+opcode  imm   src   description                                          reference 
+======  ====  ====  ===================================================  ========================================
+0x04    any   0x00  dst = (uint32_t)(dst + imm)                          `Arithmetic instructions`_
+0x05    0x00  0x00  goto +offset                                         `Jump instructions`_
+0x07    any   0x00  dst += imm                                           `Arithmetic instructions`_
+0x0c    0x00  any   dst = (uint32_t)(dst + src)                          `Arithmetic instructions`_
+0x0f    0x00  any   dst += src                                           `Arithmetic instructions`_
+0x14    any   0x00  dst = (uint32_t)(dst - imm)                          `Arithmetic instructions`_
+0x15    any   0x00  if dst == imm goto +offset                           `Jump instructions`_
+0x16    any   0x00  if (uint32_t)dst == imm goto +offset                 `Jump instructions`_
+0x17    any   0x00  dst -= imm                                           `Arithmetic instructions`_
+0x18    0x00  0x00  dst = imm64                                          `Load and store instructions`_
+0x1c    0x00  any   dst = (uint32_t)(dst - src)                          `Arithmetic instructions`_
+0x1d    0x00  any   if dst == src goto +offset                           `Jump instructions`_
+0x1e    0x00  any   if (uint32_t)dst == (uint32_t)src goto +offset       `Jump instructions`_
+0x1f    0x00  any   dst -= src                                           `Arithmetic instructions`_
+0x20    any   any   (deprecated, implementation-specific)                `Legacy BPF Packet access instructions`_
+0x24    any   0x00  dst = (uint32_t)(dst \* imm)                         `Arithmetic instructions`_
+0x25    any   0x00  if dst > imm goto +offset                            `Jump instructions`_
+0x26    any   0x00  if (uint32_t)dst > imm goto +offset                  `Jump instructions`_
+0x27    any   0x00  dst \*= imm                                          `Arithmetic instructions`_
+0x28    any   any   (deprecated, implementation-specific)                `Legacy BPF Packet access instructions`_
+0x2c    0x00  any   dst = (uint32_t)(dst \* src)                         `Arithmetic instructions`_
+0x2d    0x00  any   if dst > src goto +offset                            `Jump instructions`_
+0x2e    0x00  any   if (uint32_t)dst > (uint32_t)src goto +offset        `Jump instructions`_
+0x2f    0x00  any   dst \*= src                                          `Arithmetic instructions`_
+0x30    any   any   (deprecated, implementation-specific)                `Legacy BPF Packet access instructions`_
+0x34    any   0x00  dst = (uint32_t)((imm != 0) ? (dst / imm) : 0)       `Arithmetic instructions`_
+0x35    any   0x00  if dst >= imm goto +offset                           `Jump instructions`_
+0x36    any   0x00  if (uint32_t)dst >= imm goto +offset                 `Jump instructions`_
+0x37    any   0x00  dst = (imm != 0) ? (dst / imm) : 0                   `Arithmetic instructions`_
+0x38    any   any   (deprecated, implementation-specific)                `Legacy BPF Packet access instructions`_
+0x3c    0x00  any   dst = (uint32_t)((imm != 0) ? (dst / src) : 0)       `Arithmetic instructions`_
+0x3d    0x00  any   if dst >= src goto +offset                           `Jump instructions`_
+0x3e    0x00  any   if (uint32_t)dst >= (uint32_t)src goto +offset       `Jump instructions`_
+0x3f    0x00  any   dst = (src !+ 0) ? (dst / src) : 0                   `Arithmetic instructions`_
+0x40    any   any   (deprecated, implementation-specific)                `Legacy BPF Packet access instructions`_
+0x44    any   0x00  dst = (uint32_t)(dst \| imm)                         `Arithmetic instructions`_
+0x45    any   0x00  if dst & imm goto +offset                            `Jump instructions`_
+0x46    any   0x00  if (uint32_t)dst & imm goto +offset                  `Jump instructions`_
+0x47    any   0x00  dst \|= imm                                          `Arithmetic instructions`_
+0x48    any   any   (deprecated, implementation-specific)                `Legacy BPF Packet access instructions`_
+0x4c    0x00  any   dst = (uint32_t)(dst \| src)                         `Arithmetic instructions`_
+0x4d    0x00  any   if dst & src goto +offset                            `Jump instructions`_
+0x4e    0x00  any   if (uint32_t)dst & (uint32_t)src goto +offset        `Jump instructions`_
+0x4f    0x00  any   dst \|= src                                          `Arithmetic instructions`_
+0x50    any   any   (deprecated, implementation-specific)                `Legacy BPF Packet access instructions`_
+0x54    any   0x00  dst = (uint32_t)(dst & imm)                          `Arithmetic instructions`_
+0x55    any   0x00  if dst != imm goto +offset                           `Jump instructions`_
+0x56    any   0x00  if (uint32_t)dst != imm goto +offset                 `Jump instructions`_
+0x57    any   0x00  dst &= imm                                           `Arithmetic instructions`_
+0x58    any   any   (deprecated, implementation-specific)                `Legacy BPF Packet access instructions`_
+0x5c    0x00  any   dst = (uint32_t)(dst & src)                          `Arithmetic instructions`_
+0x5d    0x00  any   if dst != src goto +offset                           `Jump instructions`_
+0x5e    0x00  any   if (uint32_t)dst != (uint32_t)src goto +offset       `Jump instructions`_
+0x5f    0x00  any   dst &= src                                           `Arithmetic instructions`_
+0x61    0x00  any   dst = \*(uint32_t \*)(src + offset)                  `Load and store instructions`_
+0x62    any   0x00  \*(uint32_t \*)(dst + offset) = imm                  `Load and store instructions`_
+0x63    0x00  any   \*(uint32_t \*)(dst + offset) = src                  `Load and store instructions`_
+0x64    any   0x00  dst = (uint32_t)(dst << imm)                         `Arithmetic instructions`_
+0x65    any   0x00  if dst s> imm goto +offset                           `Jump instructions`_
+0x66    any   0x00  if (int32_t)dst s> (int32_t)imm goto +offset         `Jump instructions`_
+0x67    any   0x00  dst <<= imm                                          `Arithmetic instructions`_
+0x69    0x00  any   dst = \*(uint16_t \*)(src + offset)                  `Load and store instructions`_
+0x6a    any   0x00  \*(uint16_t \*)(dst + offset) = imm                  `Load and store instructions`_
+0x6b    0x00  any   \*(uint16_t \*)(dst + offset) = src                  `Load and store instructions`_
+0x6c    0x00  any   dst = (uint32_t)(dst << src)                         `Arithmetic instructions`_
+0x6d    0x00  any   if dst s> src goto +offset                           `Jump instructions`_
+0x6e    0x00  any   if (int32_t)dst s> (int32_t)src goto +offset         `Jump instructions`_
+0x6f    0x00  any   dst <<= src                                          `Arithmetic instructions`_
+0x71    0x00  any   dst = \*(uint8_t \*)(src + offset)                   `Load and store instructions`_
+0x72    any   0x00  \*(uint8_t \*)(dst + offset) = imm                   `Load and store instructions`_
+0x73    0x00  any   \*(uint8_t \*)(dst + offset) = src                   `Load and store instructions`_
+0x74    any   0x00  dst = (uint32_t)(dst >> imm)                         `Arithmetic instructions`_
+0x75    any   0x00  if dst s>= imm goto +offset                          `Jump instructions`_
+0x76    any   0x00  if (int32_t)dst s>= (int32_t)imm goto +offset        `Jump instructions`_
+0x77    any   0x00  dst >>= imm                                          `Arithmetic instructions`_
+0x79    0x00  any   dst = \*(uint64_t \*)(src + offset)                  `Load and store instructions`_
+0x7a    any   0x00  \*(uint64_t \*)(dst + offset) = imm                  `Load and store instructions`_
+0x7b    0x00  any   \*(uint64_t \*)(dst + offset) = src                  `Load and store instructions`_
+0x7c    0x00  any   dst = (uint32_t)(dst >> src)                         `Arithmetic instructions`_
+0x7d    0x00  any   if dst s>= src goto +offset                          `Jump instructions`_
+0x7e    0x00  any   if (int32_t)dst s>= (int32_t)src goto +offset        `Jump instructions`_
+0x7f    0x00  any   dst >>= src                                          `Arithmetic instructions`_
+0x84    0x00  0x00  dst = (uint32_t)-dst                                 `Arithmetic instructions`_
+0x85    any   0x00  call imm                                             `Jump instructions`_
+0x87    0x00  0x00  dst = -dst                                           `Arithmetic instructions`_
+0x94    any   0x00  dst = (uint32_t)((imm != 0) ? (dst % imm) : imm)     `Arithmetic instructions`_
+0x95    0x00  0x00  return                                               `Jump instructions`_
+0x97    any   0x00  dst = (imm != 0) ? (dst % imm) : imm                 `Arithmetic instructions`_
+0x9c    0x00  any   dst = (uint32_t)((src != 0) ? (dst % src) : src)     `Arithmetic instructions`_
+0x9f    0x00  any   dst = (src != 0) ? (dst % src) : src                 `Arithmetic instructions`_
+0xa4    any   0x00  dst = (uint32_t)(dst ^ imm)                          `Arithmetic instructions`_
+0xa5    any   0x00  if dst < imm goto +offset                            `Jump instructions`_
+0xa6    any   0x00  if (uint32_t)dst < imm goto +offset                  `Jump instructions`_
+0xa7    any   0x00  dst ^= imm                                           `Arithmetic instructions`_
+0xac    0x00  any   dst = (uint32_t)(dst ^ src)                          `Arithmetic instructions`_
+0xad    0x00  any   if dst < src goto +offset                            `Jump instructions`_
+0xae    0x00  any   if (uint32_t)dst < (uint32_t)src goto +offset        `Jump instructions`_
+0xaf    0x00  any   dst ^= src                                           `Arithmetic instructions`_
+0xb4    any   0x00  dst = (uint32_t) imm                                 `Arithmetic instructions`_
+0xb5    any   0x00  if dst <= imm goto +offset                           `Jump instructions`_
+0xa6    any   0x00  if (uint32_t)dst <= imm goto +offset                 `Jump instructions`_
+0xb7    any   0x00  dst = imm                                            `Arithmetic instructions`_
+0xbc    0x00  any   dst = (uint32_t) src                                 `Arithmetic instructions`_
+0xbd    0x00  any   if dst <= src goto +offset                           `Jump instructions`_
+0xbe    0x00  any   if (uint32_t)dst <= (uint32_t)src goto +offset       `Jump instructions`_
+0xbf    0x00  any   dst = src                                            `Arithmetic instructions`_
+0xc3    0x00  any   lock \*(uint32_t \*)(dst + offset) += src            `Atomic operations`_
+0xc3    0x01  any   lock::                                               `Atomic operations`_
 
-                  *(uint32_t *)(dst + offset) += src
-                  src = *(uint32_t *)(dst + offset)
-0xc3    0x40  \*(uint32_t \*)(dst + offset) \|= src                `Atomic operations`_
-0xc3    0x41  lock::                                               `Atomic operations`_
+                        *(uint32_t *)(dst + offset) += src
+                        src = *(uint32_t *)(dst + offset)
+0xc3    0x40  any   \*(uint32_t \*)(dst + offset) \|= src                `Atomic operations`_
+0xc3    0x41  any   lock::                                               `Atomic operations`_
 
-                  *(uint32_t *)(dst + offset) |= src
-                  src = *(uint32_t *)(dst + offset)
-0xc3    0x50  \*(uint32_t \*)(dst + offset) &= src                 `Atomic operations`_
-0xc3    0x51  lock::                                               `Atomic operations`_
+                        *(uint32_t *)(dst + offset) |= src
+                        src = *(uint32_t *)(dst + offset)
+0xc3    0x50  any   \*(uint32_t \*)(dst + offset) &= src                 `Atomic operations`_
+0xc3    0x51  any   lock::                                               `Atomic operations`_
 
-                  *(uint32_t *)(dst + offset) &= src
-                  src = *(uint32_t *)(dst + offset)
-0xc3    0xa0  \*(uint32_t \*)(dst + offset) ^= src                 `Atomic operations`_
-0xc3    0xa1  lock::                                               `Atomic operations`_
+                        *(uint32_t *)(dst + offset) &= src
+                        src = *(uint32_t *)(dst + offset)
+0xc3    0xa0  any   \*(uint32_t \*)(dst + offset) ^= src                 `Atomic operations`_
+0xc3    0xa1  any   lock::                                               `Atomic operations`_
 
-                  *(uint32_t *)(dst + offset) ^= src
-                  src = *(uint32_t *)(dst + offset)
-0xc3    0xe1  lock::                                               `Atomic operations`_
+                        *(uint32_t *)(dst + offset) ^= src
+                        src = *(uint32_t *)(dst + offset)
+0xc3    0xe1  any   lock::                                               `Atomic operations`_
 
-                  temp = *(uint32_t *)(dst + offset)
-                  *(uint32_t *)(dst + offset) = src
-                  src = temp
-0xc3    0xf1  lock::                                               `Atomic operations`_
+                        temp = *(uint32_t *)(dst + offset)
+                        *(uint32_t *)(dst + offset) = src
+                        src = temp
+0xc3    0xf1  any   lock::                                               `Atomic operations`_
 
-                  temp = *(uint32_t *)(dst + offset)
-                  if *(uint32_t)(dst + offset) == R0
-                     *(uint32_t)(dst + offset) = src
-                  R0 = temp
-0xc4    any   dst = (uint32_t)(dst s>> imm)                        `Arithmetic instructions`_
-0xc5    any   if dst s< imm goto +offset                           `Jump instructions`_
-0xc6    any   if (int32_t)dst s< (int32_t)imm goto +offset         `Jump instructions`_
-0xc7    any   dst s>>= imm                                         `Arithmetic instructions`_
-0xcc    0x00  dst = (uint32_t)(dst s>> src)                        `Arithmetic instructions`_
-0xcd    0x00  if dst s< src goto +offset                           `Jump instructions`_
-0xce    0x00  if (int32_t)dst s< (int32_t)src goto +offset         `Jump instructions`_
-0xcf    0x00  dst s>>= src                                         `Arithmetic instructions`_
-0xd4    0x10  dst = htole16(dst)                                   `Byte swap instructions`_
-0xd4    0x20  dst = htole32(dst)                                   `Byte swap instructions`_
-0xd4    0x40  dst = htole64(dst)                                   `Byte swap instructions`_
-0xd5    any   if dst s<= imm goto +offset                          `Jump instructions`_
-0xd6    any   if (int32_t)dst s<= (int32_t)imm goto +offset        `Jump instructions`_
-0xdb    0x00  lock \*(uint64_t \*)(dst + offset) += src            `Atomic operations`_
-0xdb    0x01  lock::                                               `Atomic operations`_
+                        temp = *(uint32_t *)(dst + offset)
+                        if *(uint32_t)(dst + offset) == R0
+                           *(uint32_t)(dst + offset) = src
+                        R0 = temp
+0xc4    any   0x00  dst = (uint32_t)(dst s>> imm)                        `Arithmetic instructions`_
+0xc5    any   0x00  if dst s< imm goto +offset                           `Jump instructions`_
+0xc6    any   0x00  if (int32_t)dst s< (int32_t)imm goto +offset         `Jump instructions`_
+0xc7    any   0x00  dst s>>= imm                                         `Arithmetic instructions`_
+0xcc    0x00  any   dst = (uint32_t)(dst s>> src)                        `Arithmetic instructions`_
+0xcd    0x00  any   if dst s< src goto +offset                           `Jump instructions`_
+0xce    0x00  any   if (int32_t)dst s< (int32_t)src goto +offset         `Jump instructions`_
+0xcf    0x00  any   dst s>>= src                                         `Arithmetic instructions`_
+0xd4    0x10  0x00  dst = htole16(dst)                                   `Byte swap instructions`_
+0xd4    0x20  0x00  dst = htole32(dst)                                   `Byte swap instructions`_
+0xd4    0x40  0x00  dst = htole64(dst)                                   `Byte swap instructions`_
+0xd5    any   0x00  if dst s<= imm goto +offset                          `Jump instructions`_
+0xd6    any   0x00  if (int32_t)dst s<= (int32_t)imm goto +offset        `Jump instructions`_
+0xdb    0x00  any   lock \*(uint64_t \*)(dst + offset) += src            `Atomic operations`_
+0xdb    0x01  any   lock::                                               `Atomic operations`_
 
-                  *(uint64_t *)(dst + offset) += src
-                  src = *(uint64_t *)(dst + offset)
-0xdb    0x40  \*(uint64_t \*)(dst + offset) \|= src                `Atomic operations`_
-0xdb    0x41  lock::                                               `Atomic operations`_
+                        *(uint64_t *)(dst + offset) += src
+                        src = *(uint64_t *)(dst + offset)
+0xdb    0x40  any   \*(uint64_t \*)(dst + offset) \|= src                `Atomic operations`_
+0xdb    0x41  any   lock::                                               `Atomic operations`_
 
-                  *(uint64_t *)(dst + offset) |= src
-                  lock src = *(uint64_t *)(dst + offset)
-0xdb    0x50  \*(uint64_t \*)(dst + offset) &= src                 `Atomic operations`_
-0xdb    0x51  lock::                                               `Atomic operations`_
+                        *(uint64_t *)(dst + offset) |= src
+                        lock src = *(uint64_t *)(dst + offset)
+0xdb    0x50  any   \*(uint64_t \*)(dst + offset) &= src                 `Atomic operations`_
+0xdb    0x51  any   lock::                                               `Atomic operations`_
 
-                  *(uint64_t *)(dst + offset) &= src
-                  src = *(uint64_t *)(dst + offset)
-0xdb    0xa0  \*(uint64_t \*)(dst + offset) ^= src                 `Atomic operations`_
-0xdb    0xa1  lock::                                               `Atomic operations`_
+                        *(uint64_t *)(dst + offset) &= src
+                        src = *(uint64_t *)(dst + offset)
+0xdb    0xa0  any   \*(uint64_t \*)(dst + offset) ^= src                 `Atomic operations`_
+0xdb    0xa1  any   lock::                                               `Atomic operations`_
 
-                  *(uint64_t *)(dst + offset) ^= src
-                  src = *(uint64_t *)(dst + offset)
-0xdb    0xe1  lock::                                               `Atomic operations`_
+                        *(uint64_t *)(dst + offset) ^= src
+                        src = *(uint64_t *)(dst + offset)
+0xdb    0xe1  any   lock::                                               `Atomic operations`_
 
-                  temp = *(uint64_t *)(dst + offset)
-                  *(uint64_t *)(dst + offset) = src
-                  src = temp
-0xdb    0xf1  lock::                                               `Atomic operations`_
+                        temp = *(uint64_t *)(dst + offset)
+                        *(uint64_t *)(dst + offset) = src
+                        src = temp
+0xdb    0xf1  any   lock::                                               `Atomic operations`_
 
-                  temp = *(uint64_t *)(dst + offset)
-                  if *(uint64_t)(dst + offset) == R0
-                     *(uint64_t)(dst + offset) = src
-                  R0 = temp
-0xdc    0x10  dst = htobe16(dst)                                   `Byte swap instructions`_
-0xdc    0x20  dst = htobe32(dst)                                   `Byte swap instructions`_
-0xdc    0x40  dst = htobe64(dst)                                   `Byte swap instructions`_
-0xdd    0x00  if dst s<= src goto +offset                          `Jump instructions`_
-0xde    0x00  if (int32_t)dst s<= (int32_t)src goto +offset        `Jump instructions`_
-======  ====  ===================================================  =============
+                        temp = *(uint64_t *)(dst + offset)
+                        if *(uint64_t)(dst + offset) == R0
+                           *(uint64_t)(dst + offset) = src
+                        R0 = temp
+0xdc    0x10  0x00  dst = htobe16(dst)                                   `Byte swap instructions`_
+0xdc    0x20  0x00  dst = htobe32(dst)                                   `Byte swap instructions`_
+0xdc    0x40  0x00  dst = htobe64(dst)                                   `Byte swap instructions`_
+0xdd    0x00  any   if dst s<= src goto +offset                          `Jump instructions`_
+0xde    0x00  any   if (int32_t)dst s<= (int32_t)src goto +offset        `Jump instructions`_
+======  ====  ====  ===================================================  ========================================

--- a/isa/kernel.org/linux-historical-notes.rst
+++ b/isa/kernel.org/linux-historical-notes.rst
@@ -1,0 +1,63 @@
+.. contents::
+.. sectnum::
+
+=====================
+Linux historial notes
+=====================
+
+Legacy BPF Packet access instructions
+=====================================
+
+As mentioned in the `ISA standard documentation <https://github.com/dthaler/ebpf-docs/blob/update/isa/kernel.org/instruction-set.rst#legacy-bpf-packet-access-instructions>`_,
+Linux has special eBPF instructions for access to packet data that have been
+carried over from classic BPF to retain the performance of legacy socket
+filters running in the eBPF interpreter.
+
+The instructions come in two forms: ``BPF_ABS | <size> | BPF_LD`` and
+``BPF_IND | <size> | BPF_LD``.
+
+These instructions are used to access packet data and can only be used when
+the program context is a pointer to a networking packet.  ``BPF_ABS``
+accesses packet data at an absolute offset specified by the immediate data
+and ``BPF_IND`` access packet data at an offset that includes the value of
+a register in addition to the immediate data.
+
+These instructions have seven implicit operands:
+
+* Register R6 is an implicit input that must contain a pointer to a
+  struct sk_buff.
+* Register R0 is an implicit output which contains the data fetched from
+  the packet.
+* Registers R1-R5 are scratch registers that are clobbered by the
+  instruction.
+
+These instructions have an implicit program exit condition as well. If an
+eBPF program attempts access data beyond the packet boundary, the
+program execution will be aborted.
+
+``BPF_ABS | BPF_W | BPF_LD`` (0x20) means::
+
+  R0 = ntohl(*(u32 *) ((struct sk_buff *) R6->data + imm))
+
+where ``ntohl()`` converts a 32-bit value from network byte order to host byte order.
+
+``BPF_IND | BPF_W | BPF_LD`` (0x40) means::
+
+  R0 = ntohl(*(u32 *) ((struct sk_buff *) R6->data + src + imm))
+
+Appendix
+========
+
+For reference, the following table lists legacy Linux-specific opcodes in order by value.
+
+======  ====  ===================================================  =============
+opcode  imm   description                                          reference
+======  ====  ===================================================  =============
+0x20    any   dst = ntohl(\*(uint32_t \*)(R6->data + imm))         `Legacy BPF Packet access instructions`_
+0x28    any   dst = ntohs(\*(uint16_t \*)(R6->data + imm))         `Legacy BPF Packet access instructions`_
+0x30    any   dst = (\*(uint8_t \*)(R6->data + imm))               `Legacy BPF Packet access instructions`_
+0x38    any   dst = ntohll(\*(uint64_t \*)(R6->data + imm))        `Legacy BPF Packet access instructions`_
+0x40    any   dst = ntohl(\*(uint32_t \*)(R6->data + src + imm))   `Legacy BPF Packet access instructions`_
+0x48    any   dst = ntohs(\*(uint16_t \*)(R6->data + src + imm))   `Legacy BPF Packet access instructions`_
+0x50    any   dst = \*(uint8_t \*)(R6->data + src + imm))          `Legacy BPF Packet access instructions`_
+0x58    any   dst = ntohll(\*(uint64_t \*)(R6->data + src + imm))  `Legacy BPF Packet access instructions`_


### PR DESCRIPTION
* Move legacy packet instructions to Linux historical notes
* Fix specification of divide-by-zero and modulo-zero
* Note that imm is signed
* Fix typo in Appendix
* Add note about invalid instruction 0x8d used by clang -O0
* Add src column to Appendix
* Fix construction of imm64
* Add additional 64-bit immediate instructions

Fixes #2
Fixes #3

Signed-off-by: Dave Thaler <dthaler@microsoft.com>